### PR TITLE
feat: allow admin to open or close the game

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,129 @@
-# تم حذف المستودع
+# Millionaire Challenge / تحدي المليونير
+
+A bilingual (English/Arabic) recreation of the classic **"Who Wants to Be a Millionaire"** quiz show built for the web. The project uses Firebase for authentication, Firestore for persistent storage, and ships with a rich administration console for managing every aspect of the game experience.
+
+> ⚠️ Original sound effects are not bundled. Add the legally acquired audio cues described in [`public/assets/audio/README.md`](public/assets/audio/README.md) to unlock the full soundscape.
+
+## ✨ Feature Highlights
+
+- **Authentic gameplay** with all three lifelines (50:50, Ask the Audience, Phone a Friend), prize ladder logic, safe levels, and walk-away support.
+- **Firebase Authentication** for email/password sign-up and sign-in, plus profile persistence in Firestore.
+- **Firestore-backed content** so administrators can curate questions, answers, difficulty, and localization without touching code.
+- **Professional administration panel** with create/update/delete workflows, bilingual fields, live previews, and role gating by email.
+- **Persistent sessions** that save and resume in-progress games per user and device.
+- **Bilingual interface** (English and Arabic) with full RTL support and dynamic translations.
+- **Original audio integration hooks** ready for the official Millionaire cue sheet.
+
+## 🗂️ Project Structure
+
+```
+public/
+  index.html          # Single-page application shell
+  styles.css          # Global styling and theme
+  app.js              # SPA logic, Firebase integration, gameplay + admin code
+  assets/
+    audio/            # Drop authentic sound effects here (see README inside)
+firebase.json         # Firebase Hosting configuration
+```
+
+## 🔐 Firebase Configuration
+
+1. Create a Firebase project and enable **Email/Password** authentication.
+2. Create a **Cloud Firestore** database in production mode (or test mode during development).
+3. Copy your Firebase web app configuration from the project settings.
+4. Update the `firebaseConfig` object in [`public/app.js`](public/app.js) with your keys.
+5. (Optional) Adjust the `ADMIN_EMAILS` array in the same file with the addresses that should access the administration panel.
+
+> 💡 Consider using Firebase security rules to restrict write access to the `questions` collection to trusted admins only.
+
+## 🧑‍💻 Local Development
+
+```bash
+# Install the Firebase CLI if you have not already
+yarn global add firebase-tools    # or: npm install -g firebase-tools
+
+# Log in to Firebase
+firebase login
+
+# Serve the static app locally
+firebase emulators:start --only hosting
+# or use any static server, e.g.
+npx serve public
+```
+
+Open [http://localhost:5000](http://localhost:5000) (or the port reported by your dev server) to explore the experience.
+
+## 🧮 Data Model
+
+| Collection | Purpose | Sample Fields |
+|------------|---------|---------------|
+| `users`    | Basic profile for each authenticated user. | `displayName`, `email`, `createdAt` |
+| `questions`| Game content curated via the admin panel.  | `level` (1–15), `difficulty`, `question.en`, `question.ar`, `answers[]`, `correctIndex`, timestamps |
+| `games`    | Historical results for completed games.    | `userId`, `userName`, `prize`, `levelReached`, `status`, `createdAt` |
+
+### Question Document Schema
+
+```json
+{
+  "level": 5,
+  "difficulty": "medium",
+  "question": { "en": "Which planet is known as the Red Planet?", "ar": "أي كوكب يُعرف بالكوكب الأحمر؟" },
+  "answers": [
+    { "en": "Mars", "ar": "المريخ" },
+    { "en": "Venus", "ar": "الزهرة" },
+    { "en": "Jupiter", "ar": "المشتري" },
+    { "en": "Saturn", "ar": "زحل" }
+  ],
+  "correctIndex": 0,
+  "createdAt": "Firebase timestamp",
+  "updatedAt": "Firebase timestamp"
+}
+```
+
+Ensure there is exactly **one question per level (1–15)** to cover a complete game run. Additional questions can be rotated manually via the admin panel.
+
+## 🔊 Audio Assets
+
+Place the officially licensed Millionaire cues inside [`public/assets/audio/`](public/assets/audio) with the following filenames:
+
+| File name        | Usage                               |
+|------------------|--------------------------------------|
+| `intro.mp3`      | Played when a new game starts        |
+| `question.mp3`   | Ambient music while answering        |
+| `final-answer.mp3` | Played after locking in an answer |
+| `correct.mp3`    | Celebration for correct answers      |
+| `wrong.mp3`      | Reveal for incorrect answers         |
+
+The game gracefully degrades (no crash) if the audio files are missing, but the immersive experience depends on them.
+
+## 🌐 Multiple Languages
+
+- Toggle between English and Arabic via the buttons in the hero banner.
+- Interface copy is translated dynamically, including placeholders and button labels.
+- Questions and answers support both languages. Populate both fields in the admin panel for a complete bilingual experience.
+
+## 🛡️ Administration
+
+- Only emails listed in `ADMIN_EMAILS` can access the admin panel.
+- The panel allows adding, editing, and deleting questions across the 15 difficulty levels.
+- Use the "Reset form" button to clear the editor, and "Back to menu" to return to the player dashboard.
+- All edits are persisted to Firestore with timestamp metadata.
+
+## 🇸🇦 ملاحظات عربية سريعة
+
+- قم بتحديث إعدادات Firebase في ملف [`public/app.js`](public/app.js) قبل النشر.
+- أضف الأصوات الأصلية للبرنامج في مجلد `public/assets/audio` بنفس أسماء الملفات المذكورة.
+- لتعيين مسؤولين جدد للوحة التحكم، حدّث مصفوفة `ADMIN_EMAILS` وأعد النشر.
+- يمكن تشغيل المشروع محلياً باستخدام Firebase CLI (`firebase emulators:start --only hosting`).
+
+## 🚀 Deployment
+
+```bash
+firebase deploy --only hosting
+```
+
+Deploying publishes the static assets to Firebase Hosting using the configuration in `firebase.json`.
+
+---
+
+Enjoy crafting your own Millionaire journey! 🎉

--- a/public/app.js
+++ b/public/app.js
@@ -1,0 +1,1311 @@
+import { initializeApp } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js";
+import {
+  getAuth,
+  onAuthStateChanged,
+  createUserWithEmailAndPassword,
+  signInWithEmailAndPassword,
+  signOut,
+  updateProfile,
+} from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
+import {
+  getFirestore,
+  collection,
+  addDoc,
+  doc,
+  getDocs,
+  onSnapshot,
+  updateDoc,
+  deleteDoc,
+  query,
+  orderBy,
+  serverTimestamp,
+  setDoc,
+} from "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js";
+
+// TODO: Replace the following configuration with your Firebase project details.
+// Firebase console: https://console.firebase.google.com
+const firebaseConfig = {
+  apiKey: "YOUR_API_KEY",
+  authDomain: "YOUR_AUTH_DOMAIN",
+  projectId: "YOUR_PROJECT_ID",
+  storageBucket: "YOUR_STORAGE_BUCKET",
+  messagingSenderId: "YOUR_MESSAGING_SENDER_ID",
+  appId: "YOUR_APP_ID",
+};
+
+const ADMIN_EMAILS = ["admin@example.com"];
+
+const app = initializeApp(firebaseConfig);
+const auth = getAuth(app);
+const db = getFirestore(app);
+const gameAvailabilityRef = doc(db, "settings", "gameAvailability");
+let unsubscribeGameAvailability = null;
+
+const translations = {
+  en: {
+    app: {
+      title: "Millionaire Challenge",
+      subtitle: "Rise through the prize ladder and claim the million!",
+    },
+    auth: {
+      heading: "Join the game",
+      description: "Create an account or sign in to sync your progress across devices.",
+      registerTitle: "Register",
+      loginTitle: "Login",
+      displayName: "Display name",
+      email: "Email",
+      password: "Password",
+      register: "Create account",
+      login: "Sign in",
+    },
+    menu: {
+      welcome: "Welcome back",
+      logout: "Logout",
+      start: "Start new game",
+      resume: "Resume last session",
+      admin: "Open administration panel",
+      closed: "The game is currently closed. Please check back soon.",
+    },
+    game: {
+      questionCounter: "Question",
+      currentPrize: "Guaranteed prize",
+      ladderTitle: "Prize ladder",
+      walkAway: "Walk away",
+      lifelines: {
+        fifty: "50 : 50",
+        audience: "Ask the audience",
+        phone: "Phone a friend",
+      },
+      messages: {
+        fetching: "Fetching questions…",
+        noQuestions: "Not enough questions available for a full game.",
+        correct: "Correct! You're climbing the ladder.",
+        wrong: "Incorrect. You've fallen back to the last safe prize.",
+        walkAway: "You walked away with",
+        win: "Incredible! You're the Millionaire!",
+        friend: "Your friend thinks the correct answer is",
+        used: "This lifeline has already been used.",
+        saved: "Game progress saved.",
+        resumed: "Resuming your previous game session.",
+      },
+    },
+    admin: {
+      heading: "Question management",
+      description: "Create, edit, and remove questions to curate the Millionaire experience.",
+      level: "Question level (1-15)",
+      difficulty: "Difficulty",
+      questionEn: "Question (English)",
+      questionAr: "Question (Arabic)",
+      answersEn: "Answers (English)",
+      answersAr: "Answers (Arabic)",
+      correct: "Correct answer index",
+      saveQuestion: "Save question",
+      reset: "Reset form",
+      back: "Back to menu",
+      createSuccess: "Question saved successfully.",
+      deleteSuccess: "Question deleted.",
+      deleteConfirm: "Delete this question?",
+      errorSave: "Unable to save the question. Please try again.",
+      errorDelete: "Unable to delete the question. Please try again.",
+      difficulties: {
+        easy: "Easy",
+        medium: "Medium",
+        hard: "Hard",
+      },
+      empty: "No questions found. Use the form above to add one.",
+      edit: "Edit",
+      delete: "Delete",
+      gameStatus: {
+        title: "Game availability",
+        description: "Control whether players can access the Millionaire challenge.",
+        statusOpen: "Open to players",
+        statusClosed: "Closed for maintenance",
+        openAction: "Open game",
+        closeAction: "Close game",
+        saving: "Updating…",
+        updated: "Game availability updated.",
+        error: "Unable to update the game availability. Please try again.",
+        lastUpdated: "Last updated",
+        updatedBy: "by",
+        unknownAdmin: "Unknown administrator",
+      },
+    },
+    misc: {
+      loading: "Loading…",
+    },
+  },
+  ar: {
+    app: {
+      title: "تحدي المليونير",
+      subtitle: "تدرّج عبر سلم الجوائز واصعد نحو المليون!",
+    },
+    auth: {
+      heading: "انضم إلى اللعبة",
+      description: "أنشئ حسابًا أو سجّل الدخول لمزامنة تقدمك على جميع الأجهزة.",
+      registerTitle: "تسجيل جديد",
+      loginTitle: "تسجيل الدخول",
+      displayName: "اسم العرض",
+      email: "البريد الإلكتروني",
+      password: "كلمة المرور",
+      register: "إنشاء حساب",
+      login: "دخول",
+    },
+    menu: {
+      welcome: "مرحبًا بعودتك",
+      logout: "تسجيل الخروج",
+      start: "بدء لعبة جديدة",
+      resume: "متابعة اللعبة السابقة",
+      admin: "فتح لوحة الإدارة",
+      closed: "اللعبة مغلقة حاليًا. نرجو معاودة المحاولة لاحقًا.",
+    },
+    game: {
+      questionCounter: "السؤال",
+      currentPrize: "الجائزة المضمونة",
+      ladderTitle: "سلم الجوائز",
+      walkAway: "الانسحاب بالجائزة",
+      lifelines: {
+        fifty: "٥٠ : ٥٠",
+        audience: "اسأل الجمهور",
+        phone: "اتصل بصديق",
+      },
+      messages: {
+        fetching: "جاري جلب الأسئلة…",
+        noQuestions: "لا توجد أسئلة كافية لإكمال لعبة كاملة.",
+        correct: "إجابة صحيحة! أنت تقترب من القمة.",
+        wrong: "إجابة خاطئة. عدتَ إلى آخر جائزة مضمونة.",
+        walkAway: "انسحبت بالجائزة",
+        win: "مذهل! لقد أصبحت مليونيرًا!",
+        friend: "صديقك يعتقد أن الإجابة الصحيحة هي",
+        used: "تم استخدام وسيلة المساعدة بالفعل.",
+        saved: "تم حفظ تقدم اللعبة.",
+        resumed: "جاري استئناف جلستك السابقة.",
+      },
+    },
+    admin: {
+      heading: "إدارة الأسئلة",
+      description: "أنشئ الأسئلة وعدّلها واحذفها لتخصيص تجربة المليونير.",
+      level: "مستوى السؤال (١-١٥)",
+      difficulty: "درجة الصعوبة",
+      questionEn: "السؤال (بالإنجليزية)",
+      questionAr: "السؤال (بالعربية)",
+      answersEn: "الإجابات (بالإنجليزية)",
+      answersAr: "الإجابات (بالعربية)",
+      correct: "خيار الإجابة الصحيحة",
+      saveQuestion: "حفظ السؤال",
+      reset: "إعادة ضبط النموذج",
+      back: "العودة إلى القائمة",
+      createSuccess: "تم حفظ السؤال بنجاح.",
+      deleteSuccess: "تم حذف السؤال.",
+      deleteConfirm: "هل تريد حذف هذا السؤال؟",
+      errorSave: "تعذر حفظ السؤال. حاول مرة أخرى.",
+      errorDelete: "تعذر حذف السؤال. حاول مرة أخرى.",
+      difficulties: {
+        easy: "سهل",
+        medium: "متوسط",
+        hard: "صعب",
+      },
+      empty: "لا توجد أسئلة. استخدم النموذج أعلاه لإضافة سؤال.",
+      edit: "تعديل",
+      delete: "حذف",
+      gameStatus: {
+        title: "حالة توفر اللعبة",
+        description: "تحكم في إمكانية دخول اللاعبين إلى تجربة المليونير.",
+        statusOpen: "مفتوحة للاعبين",
+        statusClosed: "مغلقة للصيانة",
+        openAction: "فتح اللعبة",
+        closeAction: "إغلاق اللعبة",
+        saving: "جاري التحديث…",
+        updated: "تم تحديث حالة توفر اللعبة.",
+        error: "تعذر تحديث حالة توفر اللعبة. حاول مرة أخرى.",
+        lastUpdated: "آخر تحديث",
+        updatedBy: "بواسطة",
+        unknownAdmin: "مسؤول غير معروف",
+      },
+    },
+    misc: {
+      loading: "جاري التحميل…",
+    },
+  },
+};
+
+const prizeLadder = [
+  { level: 1, amount: 100 },
+  { level: 2, amount: 200 },
+  { level: 3, amount: 300 },
+  { level: 4, amount: 500 },
+  { level: 5, amount: 1000 },
+  { level: 6, amount: 2000 },
+  { level: 7, amount: 4000 },
+  { level: 8, amount: 8000 },
+  { level: 9, amount: 16000 },
+  { level: 10, amount: 32000 },
+  { level: 11, amount: 64000 },
+  { level: 12, amount: 125000 },
+  { level: 13, amount: 250000 },
+  { level: 14, amount: 500000 },
+  { level: 15, amount: 1000000 },
+];
+
+const SAFE_LEVELS = new Set([5, 10, 15]);
+const LOCAL_STORAGE_KEY_PREFIX = "millionaire-session-";
+
+const elements = {
+  sections: {
+    auth: document.getElementById("auth-section"),
+    menu: document.getElementById("menu-section"),
+    game: document.getElementById("game-section"),
+    admin: document.getElementById("admin-section"),
+  },
+  toast: document.getElementById("toast"),
+  language: {
+    en: document.getElementById("lang-en"),
+    ar: document.getElementById("lang-ar"),
+  },
+  playerName: document.getElementById("player-name"),
+  logout: document.getElementById("logout-btn"),
+  startGame: document.getElementById("start-game-btn"),
+  resumeGame: document.getElementById("resume-game-btn"),
+  openAdmin: document.getElementById("open-admin-btn"),
+  menuNotice: document.getElementById("game-availability"),
+  questionCounter: document.getElementById("question-counter"),
+  currentPrize: document.getElementById("current-prize"),
+  questionText: document.getElementById("question-text"),
+  answers: document.getElementById("answers"),
+  ladder: document.getElementById("ladder"),
+  lifelines: {
+    fifty: document.getElementById("lifeline-5050"),
+    audience: document.getElementById("lifeline-audience"),
+    phone: document.getElementById("lifeline-phone"),
+  },
+  walkAway: document.getElementById("walk-away-btn"),
+  registerForm: document.getElementById("register-form"),
+  loginForm: document.getElementById("login-form"),
+  admin: {
+    form: document.getElementById("question-form"),
+    reset: document.getElementById("reset-form"),
+    list: document.getElementById("question-list"),
+    level: document.getElementById("question-level"),
+    difficulty: document.getElementById("question-difficulty"),
+    questionEn: document.getElementById("question-en"),
+    questionAr: document.getElementById("question-ar"),
+    correctIndex: document.getElementById("correct-index"),
+    id: document.getElementById("question-id"),
+    back: document.getElementById("back-to-menu"),
+    availabilityIndicator: document.getElementById("game-status-indicator"),
+    availabilityMeta: document.getElementById("game-status-meta"),
+    toggleAvailability: document.getElementById("toggle-game-status"),
+  },
+};
+const state = {
+  user: null,
+  language: "en",
+  game: null,
+  answering: false,
+  config: {
+    gameOpen: true,
+    updatedAt: null,
+    updatedByName: null,
+    updatedByEmail: null,
+    updatedById: null,
+  },
+  audio: {
+    intro: createAudio("assets/audio/intro.mp3"),
+    question: createAudio("assets/audio/question.mp3"),
+    final: createAudio("assets/audio/final-answer.mp3"),
+    correct: createAudio("assets/audio/correct.mp3"),
+    wrong: createAudio("assets/audio/wrong.mp3"),
+  },
+};
+
+function createAudio(src) {
+  const audio = new Audio(src);
+  audio.preload = "none";
+  audio.volume = 0.75;
+  return audio;
+}
+
+function showToast(message) {
+  if (!elements.toast) return;
+  elements.toast.textContent = message;
+  elements.toast.classList.add("visible");
+  setTimeout(() => {
+    elements.toast.classList.remove("visible");
+  }, 3000);
+}
+
+function translate(keyPath) {
+  const keys = keyPath.split(".");
+  let value = translations[state.language];
+  for (const key of keys) {
+    if (!value) break;
+    value = value[key];
+  }
+  return value ?? keyPath;
+}
+
+function applyTranslations() {
+  document.documentElement.lang = state.language;
+  document.documentElement.dir = state.language === "ar" ? "rtl" : "ltr";
+
+  document.querySelectorAll("[data-i18n]").forEach((el) => {
+    const key = el.dataset.i18n;
+    const translation = translate(key);
+    if (translation) {
+      el.textContent = translation;
+    }
+  });
+
+  document.querySelectorAll("[data-i18n-placeholder]").forEach((el) => {
+    const key = el.dataset.i18nPlaceholder;
+    const translation = translate(key);
+    if (translation && "placeholder" in el) {
+      el.placeholder = translation;
+    }
+  });
+
+  elements.language.en.classList.toggle("active", state.language === "en");
+  elements.language.ar.classList.toggle("active", state.language === "ar");
+
+  refreshGameStatusUI();
+
+  if (state.game) {
+    renderQuestion();
+    updateGameHeader();
+    renderLadder();
+  }
+}
+
+function setLanguage(language) {
+  if (state.language === language) return;
+  state.language = language;
+  localStorage.setItem("millionaire-language", language);
+  applyTranslations();
+}
+
+function getLocale() {
+  return state.language === "ar" ? "ar-EG" : "en-US";
+}
+
+function formatCurrency(amount) {
+  const locale = getLocale();
+  return new Intl.NumberFormat(locale, {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  }).format(amount);
+}
+
+function formatDateTime(date) {
+  if (!date) return "";
+  const locale = getLocale();
+  try {
+    return new Intl.DateTimeFormat(locale, {
+      dateStyle: "medium",
+      timeStyle: "short",
+    }).format(date);
+  } catch (error) {
+    console.error("Failed to format date", error);
+    return date.toLocaleString?.() ?? String(date);
+  }
+}
+
+function refreshGameStatusUI() {
+  const isOpen = Boolean(state.config.gameOpen);
+
+  if (elements.startGame) {
+    elements.startGame.disabled = !isOpen;
+    elements.startGame.setAttribute("aria-disabled", String(!isOpen));
+    if (!isOpen) {
+      elements.startGame.title = translate("menu.closed");
+    } else {
+      elements.startGame.removeAttribute("title");
+    }
+  }
+
+  if (elements.resumeGame) {
+    elements.resumeGame.disabled = !isOpen;
+    elements.resumeGame.setAttribute("aria-disabled", String(!isOpen));
+    if (!isOpen) {
+      elements.resumeGame.title = translate("menu.closed");
+    } else {
+      elements.resumeGame.removeAttribute("title");
+    }
+  }
+
+  if (elements.menuNotice) {
+    elements.menuNotice.textContent = translate("menu.closed");
+    elements.menuNotice.classList.toggle("hidden", isOpen);
+  }
+
+  const indicator = elements.admin.availabilityIndicator;
+  if (indicator) {
+    indicator.dataset.status = isOpen ? "open" : "closed";
+    const key = isOpen
+      ? "admin.gameStatus.statusOpen"
+      : "admin.gameStatus.statusClosed";
+    indicator.textContent = translate(key);
+  }
+
+  const toggleButton = elements.admin.toggleAvailability;
+  if (toggleButton) {
+    const isLoading = toggleButton.dataset.loading === "true";
+    const canManage = Boolean(state.user && ADMIN_EMAILS.includes(state.user.email));
+    toggleButton.disabled = isLoading || !canManage;
+    if (isLoading) {
+      toggleButton.textContent = translate("admin.gameStatus.saving");
+    } else {
+      const actionKey = isOpen
+        ? "admin.gameStatus.closeAction"
+        : "admin.gameStatus.openAction";
+      toggleButton.textContent = translate(actionKey);
+    }
+    if (!canManage) {
+      toggleButton.title = translate("admin.gameStatus.description");
+    } else {
+      toggleButton.removeAttribute("title");
+    }
+  }
+
+  const meta = elements.admin.availabilityMeta;
+  if (meta) {
+    const { updatedAt, updatedByName, updatedByEmail, updatedById } = state.config;
+    if (updatedAt) {
+      const formatted = formatDateTime(updatedAt);
+      const by =
+        updatedByName ||
+        updatedByEmail ||
+        updatedById ||
+        translate("admin.gameStatus.unknownAdmin");
+      meta.textContent = `${translate("admin.gameStatus.lastUpdated")} ${formatted} ${translate(
+        "admin.gameStatus.updatedBy"
+      )} ${by}`;
+    } else {
+      meta.textContent = "";
+    }
+  }
+}
+
+function initGameStatusListener() {
+  if (typeof unsubscribeGameAvailability === "function") {
+    unsubscribeGameAvailability();
+  }
+
+  unsubscribeGameAvailability = onSnapshot(
+    gameAvailabilityRef,
+    (snapshot) => {
+      if (snapshot.exists()) {
+        const data = snapshot.data();
+        state.config.gameOpen = data.isOpen !== false;
+        const updatedAt = data.updatedAt;
+        state.config.updatedAt =
+          updatedAt && typeof updatedAt.toDate === "function"
+            ? updatedAt.toDate()
+            : updatedAt
+            ? new Date(updatedAt)
+            : null;
+        state.config.updatedByName = data.updatedByName || null;
+        state.config.updatedByEmail = data.updatedByEmail || null;
+        state.config.updatedById = data.updatedBy || null;
+      } else {
+        state.config.gameOpen = true;
+        state.config.updatedAt = null;
+        state.config.updatedByName = null;
+        state.config.updatedByEmail = null;
+        state.config.updatedById = null;
+      }
+      refreshGameStatusUI();
+    },
+    (error) => {
+      console.error("Failed to observe game availability", error);
+    }
+  );
+}
+
+async function toggleGameAvailability() {
+  if (!state.user) return;
+  if (!ADMIN_EMAILS.includes(state.user.email)) return;
+
+  const button = elements.admin.toggleAvailability;
+  if (!button || button.dataset.loading === "true") return;
+
+  button.dataset.loading = "true";
+  refreshGameStatusUI();
+
+  try {
+    await setDoc(
+      gameAvailabilityRef,
+      {
+        isOpen: !state.config.gameOpen,
+        updatedAt: serverTimestamp(),
+        updatedBy: state.user.uid || null,
+        updatedByEmail: state.user.email || null,
+        updatedByName: state.user.displayName || null,
+      },
+      { merge: true }
+    );
+    state.config.gameOpen = !state.config.gameOpen;
+    state.config.updatedAt = new Date();
+    state.config.updatedByName = state.user.displayName || null;
+    state.config.updatedByEmail = state.user.email || null;
+    state.config.updatedById = state.user.uid || null;
+    showToast(translate("admin.gameStatus.updated"));
+  } catch (error) {
+    console.error("Failed to update game availability", error);
+    showToast(translate("admin.gameStatus.error"));
+  } finally {
+    button.dataset.loading = "false";
+    refreshGameStatusUI();
+  }
+}
+
+function showSection(sectionName) {
+  Object.entries(elements.sections).forEach(([name, el]) => {
+    el.classList.toggle("hidden", name !== sectionName);
+  });
+}
+
+function getSessionKey(userId) {
+  return `${LOCAL_STORAGE_KEY_PREFIX}${userId}`;
+}
+
+function saveGameState(showNotification = false) {
+  if (!state.user || !state.game) return;
+  const session = {
+    ...state.game,
+    timestamp: Date.now(),
+  };
+  localStorage.setItem(getSessionKey(state.user.uid), JSON.stringify(session));
+  if (elements.resumeGame) {
+    elements.resumeGame.classList.remove("hidden");
+  }
+  if (showNotification) {
+    showToast(translate("game.messages.saved"));
+  }
+}
+
+function loadSavedGame(userId) {
+  const raw = localStorage.getItem(getSessionKey(userId));
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed;
+  } catch (error) {
+    console.error("Failed to parse saved game", error);
+    return null;
+  }
+}
+
+function clearSavedGame(userId) {
+  localStorage.removeItem(getSessionKey(userId));
+}
+
+function buildGameSkeleton() {
+  const answersFragment = document.createDocumentFragment();
+  ["A", "B", "C", "D"].forEach((label, index) => {
+    const answer = document.createElement("div");
+    answer.className = "answer";
+    answer.dataset.index = String(index);
+    const badge = document.createElement("span");
+    badge.textContent = label;
+    const text = document.createElement("span");
+    text.className = "answer-text";
+    answer.append(badge, text);
+    answersFragment.appendChild(answer);
+  });
+  elements.answers.innerHTML = "";
+  elements.answers.appendChild(answersFragment);
+
+  renderLadder();
+}
+
+function renderLadder() {
+  elements.ladder.innerHTML = "";
+  const fragment = document.createDocumentFragment();
+  const currentLevel = state.game ? state.game.currentIndex + 1 : 0;
+
+  [...prizeLadder].reverse().forEach(({ level, amount }) => {
+    const ladderItem = document.createElement("div");
+    ladderItem.className = "ladder-item";
+    if (SAFE_LEVELS.has(level)) {
+      ladderItem.classList.add("safe");
+    }
+    if (level === currentLevel) {
+      ladderItem.classList.add("active");
+    }
+    ladderItem.dataset.level = String(level);
+
+    const label = document.createElement("span");
+    label.textContent = `${level}`;
+    const value = document.createElement("span");
+    value.textContent = formatCurrency(amount);
+    ladderItem.append(label, value);
+    fragment.appendChild(ladderItem);
+  });
+
+  elements.ladder.appendChild(fragment);
+}
+
+function updateGameHeader() {
+  if (!state.game) return;
+  const { currentIndex, safePrize } = state.game;
+  const counter = `${currentIndex + 1} / ${prizeLadder.length}`;
+  elements.questionCounter.textContent = `${translate("game.questionCounter")} ${counter}`;
+  elements.currentPrize.textContent = formatCurrency(safePrize);
+}
+
+function resetLifelines() {
+  if (!state.game) return;
+  state.game.lifelines = {
+    fifty: false,
+    audience: false,
+    phone: false,
+  };
+  state.game.fiftyFifty = null;
+  Object.values(elements.lifelines).forEach((button) => {
+    button.disabled = false;
+  });
+}
+
+function applyLifelineState() {
+  if (!state.game || !state.game.lifelines) return;
+  Object.entries(elements.lifelines).forEach(([key, button]) => {
+    button.disabled = !!state.game.lifelines[key];
+  });
+
+  if (
+    state.game.lifelines.fifty &&
+    state.game.fiftyFifty &&
+    state.game.fiftyFifty.index === state.game.currentIndex &&
+    Array.isArray(state.game.fiftyFifty.removed)
+  ) {
+    state.game.fiftyFifty.removed.forEach((index) => {
+      const answerEl = elements.answers.querySelector(`.answer[data-index="${index}"]`);
+      if (answerEl) {
+        answerEl.classList.add("hidden");
+      }
+    });
+  }
+}
+
+function renderQuestion() {
+  if (!state.game) return;
+  const question = state.game.questions[state.game.currentIndex];
+  if (!question) return;
+
+  elements.questionText.textContent =
+    state.language === "ar"
+      ? question.question.ar || question.question.en
+      : question.question.en;
+
+  const answers = elements.answers.querySelectorAll(".answer");
+  answers.forEach((answerEl) => {
+    answerEl.classList.remove("active", "correct", "wrong", "disabled", "hidden");
+    answerEl.style.display = "flex";
+    const index = Number(answerEl.dataset.index);
+    const answer = question.answers[index];
+    const text = state.language === "ar" ? answer?.ar || answer?.en : answer?.en;
+    const textContainer = answerEl.querySelector(".answer-text");
+    textContainer.textContent = text ?? "";
+  });
+
+  applyLifelineState();
+  updateGameHeader();
+}
+
+function playAudio(name) {
+  const clip = state.audio[name];
+  if (!clip) return;
+  try {
+    clip.currentTime = 0;
+    clip.play();
+  } catch (error) {
+    console.warn(`Unable to play audio ${name}`, error);
+  }
+}
+
+function calculateSafePrize(level) {
+  const safeLevel = [...SAFE_LEVELS]
+    .filter((safe) => safe <= level)
+    .sort((a, b) => b - a)[0];
+  return safeLevel ? prizeLadder[safeLevel - 1].amount : 0;
+}
+
+async function recordGameResult(result) {
+  if (!state.user) return;
+  try {
+    await addDoc(collection(db, "games"), {
+      userId: state.user.uid,
+      userName: state.user.displayName || state.user.email,
+      prize: result.prize,
+      levelReached: result.level,
+      status: result.status,
+      createdAt: serverTimestamp(),
+    });
+  } catch (error) {
+    console.error("Failed to store game result", error);
+  }
+}
+
+function handleAnswerSelection(index) {
+  if (!state.game || state.answering) return;
+  const question = state.game.questions[state.game.currentIndex];
+  if (!question) return;
+
+  state.answering = true;
+  const answers = elements.answers.querySelectorAll(".answer");
+  answers.forEach((el) => (el.classList.add("disabled")));
+  const selected = elements.answers.querySelector(`.answer[data-index="${index}"]`);
+  if (selected) {
+    selected.classList.add("active");
+  }
+
+  playAudio("final");
+
+  setTimeout(() => {
+    const isCorrect = index === question.correctIndex;
+    if (isCorrect) {
+      if (selected) selected.classList.add("correct");
+      playAudio("correct");
+      showToast(translate("game.messages.correct"));
+      state.game.currentIndex += 1;
+      state.game.fiftyFifty = null;
+      const level = state.game.currentIndex;
+      state.game.safePrize = calculateSafePrize(level);
+      state.game.lastPrize = prizeLadder[level - 1]?.amount || state.game.safePrize;
+
+      if (state.game.currentIndex >= state.game.questions.length) {
+        endGame({ status: "win", prize: prizeLadder[prizeLadder.length - 1].amount, level });
+        return;
+      }
+
+      setTimeout(() => {
+        renderQuestion();
+        renderLadder();
+        state.answering = false;
+        playAudio("question");
+        saveGameState();
+        enableAnswers();
+      }, 1500);
+    } else {
+      if (selected) selected.classList.add("wrong");
+      const correctEl = elements.answers.querySelector(
+        `.answer[data-index="${question.correctIndex}"]`
+      );
+      if (correctEl) correctEl.classList.add("correct");
+      playAudio("wrong");
+      showToast(translate("game.messages.wrong"));
+      setTimeout(() => {
+        endGame({
+          status: "lost",
+          prize: state.game.safePrize,
+          level: state.game.currentIndex + 1,
+        });
+      }, 1800);
+    }
+  }, 2200);
+}
+
+function enableAnswers() {
+  elements.answers.querySelectorAll(".answer").forEach((el) => {
+    el.classList.remove("disabled", "active", "correct", "wrong");
+  });
+  state.answering = false;
+}
+
+function endGame({ status, prize, level }) {
+  state.answering = false;
+  if (status === "win") {
+    showToast(translate("game.messages.win"));
+  } else if (status === "walk-away") {
+    showToast(`${translate("game.messages.walkAway")} ${formatCurrency(prize)}`);
+  }
+
+  recordGameResult({ status, prize, level });
+  clearSavedGame(state.user.uid);
+  state.game = null;
+  renderLadder();
+  showSection("menu");
+  if (state.user) {
+    updateMenuForUser(state.user);
+  }
+}
+
+async function fetchQuestions() {
+  try {
+    const q = query(collection(db, "questions"), orderBy("level"));
+    const snapshot = await getDocs(q);
+    const questions = snapshot.docs.map((docSnap) => {
+      const data = docSnap.data();
+      const answers = Array.isArray(data.answers) ? data.answers.slice(0, 4) : [];
+      return {
+        id: docSnap.id,
+        level: Number(data.level) || 0,
+        difficulty: data.difficulty || "easy",
+        question: data.question || { en: "", ar: "" },
+        answers: answers.map((answer) => ({ en: answer?.en || "", ar: answer?.ar || "" })),
+        correctIndex: typeof data.correctIndex === "number" ? data.correctIndex : 0,
+      };
+    });
+    return questions;
+  } catch (error) {
+    console.error("Failed to fetch questions", error);
+    showToast(translate("game.messages.noQuestions"));
+    return [];
+  }
+}
+
+async function startGame() {
+  if (!state.config.gameOpen) {
+    showToast(translate("menu.closed"));
+    return;
+  }
+  showSection("game");
+  playAudio("intro");
+  state.answering = false;
+
+  showToast(translate("game.messages.fetching"));
+  const questions = await fetchQuestions();
+  const ordered = questions
+    .filter((q) => q.level >= 1 && q.level <= prizeLadder.length)
+    .sort((a, b) => a.level - b.level);
+
+  if (ordered.length < prizeLadder.length) {
+    showToast(translate("game.messages.noQuestions"));
+    showSection("menu");
+    return;
+  }
+
+  const selected = ordered.slice(0, prizeLadder.length);
+
+  state.game = {
+    questions: selected,
+    currentIndex: 0,
+    lifelines: {
+      fifty: false,
+      audience: false,
+      phone: false,
+    },
+    safePrize: 0,
+    lastPrize: 0,
+    fiftyFifty: null,
+  };
+
+  buildGameSkeleton();
+  resetLifelines();
+  enableAnswers();
+  renderQuestion();
+  renderLadder();
+  applyLifelineState();
+  playAudio("question");
+  saveGameState();
+}
+
+function resumeSavedGame() {
+  if (!state.user) return;
+  if (!state.config.gameOpen) {
+    showToast(translate("menu.closed"));
+    return;
+  }
+  const saved = loadSavedGame(state.user.uid);
+  if (!saved) return;
+  state.game = saved;
+  buildGameSkeleton();
+  enableAnswers();
+  renderQuestion();
+  renderLadder();
+  applyLifelineState();
+  showSection("game");
+  playAudio("question");
+  showToast(translate("game.messages.resumed"));
+}
+
+function applyFiftyFifty() {
+  if (!state.game) return;
+  if (state.game.lifelines.fifty) {
+    showToast(translate("game.messages.used"));
+    return;
+  }
+  const question = state.game.questions[state.game.currentIndex];
+  const wrongIndices = [0, 1, 2, 3].filter((i) => i !== question.correctIndex);
+  const removed = shuffleArray(wrongIndices).slice(0, 2);
+  state.game.lifelines.fifty = true;
+  state.game.fiftyFifty = { index: state.game.currentIndex, removed };
+  elements.lifelines.fifty.disabled = true;
+
+  removed.forEach((index) => {
+    const answerEl = elements.answers.querySelector(`.answer[data-index="${index}"]`);
+    if (answerEl) {
+      answerEl.classList.add("hidden");
+    }
+  });
+  saveGameState();
+}
+
+function applyAudienceHelp() {
+  if (!state.game) return;
+  if (state.game.lifelines.audience) {
+    showToast(translate("game.messages.used"));
+    return;
+  }
+  state.game.lifelines.audience = true;
+  elements.lifelines.audience.disabled = true;
+
+  const question = state.game.questions[state.game.currentIndex];
+  const base = [25, 25, 25, 25];
+  base[question.correctIndex] += 25;
+  const distribution = generateAudienceDistribution(base, question.correctIndex);
+  const formatted = distribution
+    .map((value, index) => `${String.fromCharCode(65 + index)}: ${value}%`)
+    .join(" | ");
+  showToast(formatted);
+  saveGameState();
+}
+
+function generateAudienceDistribution(base, correctIndex) {
+  const randomised = base.map((value, index) => {
+    const bias = index === correctIndex ? 15 : 0;
+    return Math.max(5, Math.round(value + bias + (Math.random() * 20 - 10)));
+  });
+  const total = randomised.reduce((sum, value) => sum + value, 0);
+  let distribution = randomised.map((value) => Math.round((value / total) * 100));
+  let diff = 100 - distribution.reduce((sum, value) => sum + value, 0);
+  let i = 0;
+  while (diff !== 0 && i < 100) {
+    const targetIndex = diff > 0 ? correctIndex : i % distribution.length;
+    if (diff > 0) {
+      distribution[targetIndex] += 1;
+      diff -= 1;
+    } else if (distribution[targetIndex] > 0) {
+      distribution[targetIndex] -= 1;
+      diff += 1;
+    }
+    i += 1;
+  }
+  return distribution;
+}
+
+function applyPhoneAFriend() {
+  if (!state.game) return;
+  if (state.game.lifelines.phone) {
+    showToast(translate("game.messages.used"));
+    return;
+  }
+  state.game.lifelines.phone = true;
+  elements.lifelines.phone.disabled = true;
+
+  const question = state.game.questions[state.game.currentIndex];
+  const answerLetter = String.fromCharCode(65 + question.correctIndex);
+  showToast(`${translate("game.messages.friend")} ${answerLetter}`);
+  saveGameState();
+}
+
+function shuffleArray(array) {
+  for (let i = array.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [array[i], array[j]] = [array[j], array[i]];
+  }
+  return array;
+}
+
+async function upsertQuestion(event) {
+  event.preventDefault();
+  const questionId = elements.admin.id.value || null;
+  const level = Number(elements.admin.level.value);
+  const difficulty = elements.admin.difficulty.value;
+  const questionEn = elements.admin.questionEn.value.trim();
+  const questionAr = elements.admin.questionAr.value.trim();
+  const correctIndex = Number(elements.admin.correctIndex.value);
+
+  const answersEn = Array.from(document.querySelectorAll("[data-option-en]"), (input) => input.value.trim());
+  const answersAr = Array.from(document.querySelectorAll("[data-option-ar]"), (input) => input.value.trim());
+
+  const payload = {
+    level,
+    difficulty,
+    question: { en: questionEn, ar: questionAr },
+    answers: answersEn.map((en, index) => ({ en, ar: answersAr[index] })),
+    correctIndex,
+    updatedAt: serverTimestamp(),
+  };
+
+  try {
+    if (questionId) {
+      await updateDoc(doc(db, "questions", questionId), payload);
+    } else {
+      await addDoc(collection(db, "questions"), {
+        ...payload,
+        createdAt: serverTimestamp(),
+        createdBy: state.user?.uid || null,
+      });
+    }
+    showToast(translate("admin.createSuccess"));
+    elements.admin.form.reset();
+    elements.admin.id.value = "";
+    loadAdminQuestions();
+  } catch (error) {
+    console.error("Failed to save question", error);
+    showToast(translate("admin.errorSave"));
+  }
+}
+
+async function loadAdminQuestions() {
+  elements.admin.list.innerHTML = `<p>${translate("misc.loading")}</p>`;
+  const questions = await fetchQuestions();
+  if (!questions.length) {
+    elements.admin.list.innerHTML = `<p>${translate("admin.empty")}</p>`;
+    return;
+  }
+
+  const fragment = document.createDocumentFragment();
+  questions.forEach((question) => {
+    const card = document.createElement("div");
+    card.className = "question-card";
+
+    const header = document.createElement("header");
+    const title = document.createElement("h4");
+    title.textContent = `${translate("game.questionCounter")} ${question.level}`;
+    const actions = document.createElement("div");
+    const editButton = document.createElement("button");
+    editButton.textContent = translate("admin.edit");
+    editButton.className = "secondary";
+    editButton.addEventListener("click", () => populateQuestionForm(question));
+
+    const deleteButton = document.createElement("button");
+    deleteButton.textContent = translate("admin.delete");
+    deleteButton.className = "danger";
+    deleteButton.addEventListener("click", () => deleteQuestion(question.id));
+    actions.append(editButton, deleteButton);
+
+    header.append(title, actions);
+
+    const english = document.createElement("p");
+    const englishText = question.question?.en ?? "";
+    const arabicText = question.question?.ar ?? "";
+    english.textContent = englishText;
+    const arabic = document.createElement("p");
+    arabic.textContent = arabicText || englishText;
+
+    const answers = document.createElement("div");
+    question.answers.forEach((answer, index) => {
+      const pill = document.createElement("span");
+      pill.className = "option-pill";
+      const answerEn = answer?.en ?? "";
+      const answerAr = answer?.ar ?? "";
+      pill.textContent = `${String.fromCharCode(65 + index)}. ${answerEn} / ${answerAr || answerEn}`;
+      if (index === question.correctIndex) {
+        pill.style.borderColor = "var(--success)";
+        pill.style.color = "var(--success)";
+      }
+      answers.appendChild(pill);
+    });
+
+    card.append(header, english, arabic, answers);
+    fragment.appendChild(card);
+  });
+
+  elements.admin.list.innerHTML = "";
+  elements.admin.list.appendChild(fragment);
+}
+
+function populateQuestionForm(question) {
+  elements.admin.id.value = question.id;
+  elements.admin.level.value = question.level;
+  elements.admin.difficulty.value = question.difficulty;
+  elements.admin.questionEn.value = question.question.en;
+  elements.admin.questionAr.value = question.question.ar;
+  elements.admin.correctIndex.value = question.correctIndex;
+
+  document.querySelectorAll("[data-option-en]").forEach((input) => {
+    const index = Number(input.dataset.optionEn);
+    input.value = question.answers[index]?.en ?? "";
+  });
+  document.querySelectorAll("[data-option-ar]").forEach((input) => {
+    const index = Number(input.dataset.optionAr);
+    input.value = question.answers[index]?.ar ?? "";
+  });
+}
+
+async function deleteQuestion(id) {
+  if (!confirm(translate("admin.deleteConfirm"))) return;
+  try {
+    await deleteDoc(doc(db, "questions", id));
+    showToast(translate("admin.deleteSuccess"));
+    loadAdminQuestions();
+  } catch (error) {
+    console.error("Failed to delete question", error);
+    showToast(translate("admin.errorDelete"));
+  }
+}
+
+async function registerUser(event) {
+  event.preventDefault();
+  const formData = new FormData(elements.registerForm);
+  const displayName = formData.get("displayName");
+  const email = formData.get("email");
+  const password = formData.get("password");
+
+  try {
+    const credential = await createUserWithEmailAndPassword(auth, email, password);
+    if (displayName) {
+      await updateProfile(credential.user, { displayName });
+    }
+    await setDoc(doc(db, "users", credential.user.uid), {
+      displayName: displayName || "",
+      email,
+      createdAt: serverTimestamp(),
+    });
+    elements.registerForm.reset();
+  } catch (error) {
+    console.error("Registration error", error);
+    showToast(error.message);
+  }
+}
+
+async function loginUser(event) {
+  event.preventDefault();
+  const formData = new FormData(elements.loginForm);
+  const email = formData.get("email");
+  const password = formData.get("password");
+  try {
+    await signInWithEmailAndPassword(auth, email, password);
+    elements.loginForm.reset();
+  } catch (error) {
+    console.error("Login error", error);
+    showToast(error.message);
+  }
+}
+
+function updateMenuForUser(user) {
+  elements.playerName.textContent = user.displayName || user.email;
+  const saved = loadSavedGame(user.uid);
+  elements.resumeGame.classList.toggle("hidden", !saved);
+  const isAdmin = ADMIN_EMAILS.includes(user.email);
+  elements.openAdmin.classList.toggle("hidden", !isAdmin);
+  refreshGameStatusUI();
+}
+
+function onAuthChange(user) {
+  state.user = user;
+  if (user) {
+    showSection("menu");
+    updateMenuForUser(user);
+  } else {
+    showSection("auth");
+    elements.playerName.textContent = "";
+    elements.openAdmin.classList.add("hidden");
+    elements.resumeGame.classList.add("hidden");
+    state.game = null;
+  }
+  refreshGameStatusUI();
+}
+
+function initEventListeners() {
+  elements.language.en.addEventListener("click", () => setLanguage("en"));
+  elements.language.ar.addEventListener("click", () => setLanguage("ar"));
+
+  elements.logout.addEventListener("click", () => signOut(auth));
+  elements.startGame.addEventListener("click", () => startGame());
+  elements.resumeGame.addEventListener("click", () => resumeSavedGame());
+  elements.openAdmin.addEventListener("click", () => {
+    showSection("admin");
+    refreshGameStatusUI();
+    loadAdminQuestions();
+  });
+
+  elements.registerForm.addEventListener("submit", registerUser);
+  elements.loginForm.addEventListener("submit", loginUser);
+
+  elements.walkAway.addEventListener("click", () => {
+    if (!state.game) return;
+    const prize = state.game.lastPrize || state.game.safePrize;
+    endGame({ status: "walk-away", prize, level: state.game.currentIndex + 1 });
+  });
+
+  Object.values(elements.lifelines).forEach((button) => {
+    button.addEventListener("click", (event) => {
+      switch (event.target.id) {
+        case "lifeline-5050":
+          applyFiftyFifty();
+          break;
+        case "lifeline-audience":
+          applyAudienceHelp();
+          break;
+        case "lifeline-phone":
+          applyPhoneAFriend();
+          break;
+        default:
+      }
+    });
+  });
+
+  elements.answers.addEventListener("click", (event) => {
+    const target = event.target.closest(".answer");
+    if (!target) return;
+    const index = Number(target.dataset.index);
+    handleAnswerSelection(index);
+  });
+
+  elements.admin.form.addEventListener("submit", upsertQuestion);
+  elements.admin.reset.addEventListener("click", () => {
+    elements.admin.form.reset();
+    elements.admin.id.value = "";
+  });
+  if (elements.admin.toggleAvailability) {
+    elements.admin.toggleAvailability.addEventListener("click", toggleGameAvailability);
+  }
+  if (elements.admin.back) {
+    elements.admin.back.addEventListener("click", () => {
+      showSection("menu");
+      if (state.user) {
+        updateMenuForUser(state.user);
+      }
+    });
+  }
+}
+
+function restoreLanguage() {
+  const stored = localStorage.getItem("millionaire-language");
+  if (stored === "en" || stored === "ar") {
+    state.language = stored;
+  }
+  applyTranslations();
+}
+
+function setupPlaceholders() {
+  document
+    .querySelectorAll("input[data-option-en]")
+    .forEach((input, index) => {
+      input.dataset.i18nPlaceholder = `admin.answerLabelEn${index}`;
+    });
+  document
+    .querySelectorAll("input[data-option-ar]")
+    .forEach((input, index) => {
+      input.dataset.i18nPlaceholder = `admin.answerLabelAr${index}`;
+    });
+}
+
+function extendTranslations() {
+  const labelsEn = ["Answer A", "Answer B", "Answer C", "Answer D"];
+  const labelsAr = ["الإجابة أ", "الإجابة ب", "الإجابة ج", "الإجابة د"];
+  labelsEn.forEach((text, index) => {
+    translations.en.admin[`answerLabelEn${index}`] = text;
+    translations.ar.admin[`answerLabelEn${index}`] = text;
+  });
+  labelsAr.forEach((text, index) => {
+    translations.en.admin[`answerLabelAr${index}`] = text;
+    translations.ar.admin[`answerLabelAr${index}`] = text;
+  });
+}
+
+function init() {
+  extendTranslations();
+  setupPlaceholders();
+  restoreLanguage();
+  buildGameSkeleton();
+  initEventListeners();
+  initGameStatusListener();
+
+  onAuthStateChanged(auth, onAuthChange);
+}
+
+init();

--- a/public/assets/audio/README.md
+++ b/public/assets/audio/README.md
@@ -1,0 +1,11 @@
+# Audio Assets
+
+Place the "Who Wants to Be a Millionaire" sound effects in this folder using the following file names:
+
+- `intro.mp3` – opening cue played before the first question.
+- `question.mp3` – background cue that loops for active questions.
+- `final-answer.mp3` – stinger that plays after a contestant locks an answer.
+- `correct.mp3` – celebration cue for correct answers.
+- `wrong.mp3` – defeat cue for incorrect answers.
+
+> **Note:** The repository does not ship with the original audio for licensing reasons. Add legally obtained files that match these names to enable the in-game soundscape.

--- a/public/index.html
+++ b/public/index.html
@@ -1,79 +1,211 @@
 <!DOCTYPE html>
-<html lang="ar" dir="rtl">
+<html lang="en" dir="ltr">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
-    <meta
-      name="description"
-      content="تم إغلاق الموقع للأمور الأمنية"
+    <meta name="description" content="Bilingual Who Wants to Be a Millionaire experience with Firebase authentication and admin controls." />
+    <title>Millionaire Challenge</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&family=Tajawal:wght@400;600;700&display=swap"
+      rel="stylesheet"
     />
-    <title>إغلاق الموقع - Site Closure</title>
-    <style>
-      body {
-        font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-        background-color: #f8f9fa;
-        margin: 0;
-        padding: 0;
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        height: 100vh;
-        direction: rtl;
-        text-align: right;
-        color: #333;
-      }
-      .container {
-        background-color: white;
-        border-radius: 8px;
-        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-        padding: 40px;
-        max-width: 600px;
-        width: 90%;
-      }
-      h1 {
-        color: #e74c3c;
-        margin-bottom: 20px;
-        font-size: 28px;
-      }
-      p {
-        font-size: 16px;
-        line-height: 1.6;
-        margin-bottom: 15px;
-      }
-      .icon {
-        text-align: center;
-        font-size: 64px;
-        margin-bottom: 20px;
-        color: #e74c3c;
-      }
-      .footer {
-        margin-top: 30px;
-        padding-top: 20px;
-        border-top: 1px solid #eee;
-        font-size: 14px;
-        color: #777;
-      }
-      @media (max-width: 480px) {
-        .container {
-          padding: 25px;
-        }
-        h1 {
-          font-size: 24px;
-        }
-      }
-    </style>
+    <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
-    <div class="container">
-      <div class="icon">🔒</div>
-      <h1>تم إغلاق الموقع للأمور الأمنية</h1>
-      <p>نعتذر منكم، لقد تم إغلاق الموقع مؤقتاً لأسباب أمنية.</p>
-      <p>نعمل حالياً على تحسين أمان الموقع وسيتم إعادة فتحه قريباً بإذن الله.</p>
-      <p>نشكركم على تفهمكم وصبركم خلال هذه الفترة.</p>
-      <div class="footer">
-        <p>للتواصل والاستفسار: support@example.com</p>
+    <div class="toast" id="toast"></div>
+    <header>
+      <h1 data-i18n="app.title">Millionaire Challenge</h1>
+      <p data-i18n="app.subtitle">Rise through the prize ladder and claim the million!</p>
+      <div class="language-toggle">
+        <button id="lang-en" class="active">English</button>
+        <button id="lang-ar">العربية</button>
       </div>
-    </div>
+    </header>
+    <main>
+      <section id="auth-section" class="card">
+        <h2 data-i18n="auth.heading">Join the game</h2>
+        <p data-i18n="auth.description">
+          Create an account or sign in to sync your progress across devices.
+        </p>
+        <div class="auth-forms">
+          <form id="register-form">
+            <h3 data-i18n="auth.registerTitle">Register</h3>
+            <div class="form-control">
+              <label for="register-name" data-i18n="auth.displayName">Display name</label>
+              <input id="register-name" name="displayName" required />
+            </div>
+            <div class="form-control">
+              <label for="register-email" data-i18n="auth.email">Email</label>
+              <input id="register-email" name="email" type="email" required />
+            </div>
+            <div class="form-control">
+              <label for="register-password" data-i18n="auth.password">Password</label>
+              <input
+                id="register-password"
+                name="password"
+                type="password"
+                minlength="6"
+                required
+              />
+            </div>
+            <button type="submit" data-i18n="auth.register">Create account</button>
+          </form>
+          <form id="login-form">
+            <h3 data-i18n="auth.loginTitle">Login</h3>
+            <div class="form-control">
+              <label for="login-email" data-i18n="auth.email">Email</label>
+              <input id="login-email" name="email" type="email" required />
+            </div>
+            <div class="form-control">
+              <label for="login-password" data-i18n="auth.password">Password</label>
+              <input id="login-password" name="password" type="password" required />
+            </div>
+            <button type="submit" data-i18n="auth.login">Sign in</button>
+          </form>
+        </div>
+      </section>
+
+      <section id="menu-section" class="card hidden">
+        <div class="status-banner">
+          <div>
+            <span data-i18n="menu.welcome">Welcome back</span>
+            <strong id="player-name"></strong>
+          </div>
+          <button id="logout-btn" class="secondary" data-i18n="menu.logout">Logout</button>
+        </div>
+        <div id="menu-actions">
+          <button id="start-game-btn" data-i18n="menu.start">Start new game</button>
+          <button id="resume-game-btn" class="secondary hidden" data-i18n="menu.resume">
+            Resume last session
+          </button>
+          <button id="open-admin-btn" class="secondary hidden" data-i18n="menu.admin">
+            Open administration panel
+          </button>
+        </div>
+        <p id="game-availability" class="notice hidden" data-i18n="menu.closed">
+          The game is currently closed. Please check back soon.
+        </p>
+      </section>
+
+      <section id="game-section" class="card hidden">
+        <div class="status-banner">
+          <div>
+            <span data-i18n="game.questionCounter">Question</span>
+            <strong id="question-counter">1 / 15</strong>
+          </div>
+          <div>
+            <span data-i18n="game.currentPrize">Guaranteed prize</span>
+            <strong id="current-prize">$0</strong>
+          </div>
+        </div>
+        <div class="lifelines">
+          <button id="lifeline-5050" data-i18n="game.lifelines.fifty">50 : 50</button>
+          <button id="lifeline-audience" data-i18n="game.lifelines.audience">Ask the audience</button>
+          <button id="lifeline-phone" data-i18n="game.lifelines.phone">Phone a friend</button>
+        </div>
+        <div id="game-area">
+          <div class="question-box">
+            <div class="question-text" id="question-text">–</div>
+          </div>
+          <div class="answers" id="answers"></div>
+        </div>
+        <div class="card">
+          <h3 data-i18n="game.ladderTitle">Prize ladder</h3>
+          <div class="ladder" id="ladder"></div>
+          <button id="walk-away-btn" class="secondary" data-i18n="game.walkAway">
+            Walk away
+          </button>
+        </div>
+      </section>
+
+      <section id="admin-section" class="card hidden">
+        <div class="status-banner">
+          <h2 data-i18n="admin.heading">Question management</h2>
+          <button type="button" id="back-to-menu" class="secondary" data-i18n="admin.back">
+            Back to menu
+          </button>
+        </div>
+        <p data-i18n="admin.description">
+          Create, edit, and remove questions to curate the Millionaire experience.
+        </p>
+        <div class="admin-control-card">
+          <div class="admin-control-info">
+            <h3 data-i18n="admin.gameStatus.title">Game availability</h3>
+            <p data-i18n="admin.gameStatus.description">
+              Toggle whether the Millionaire experience is open to players.
+            </p>
+            <span
+              id="game-status-indicator"
+              class="status-pill"
+              data-status="open"
+              data-i18n="admin.gameStatus.statusOpen"
+            >
+              Open to players
+            </span>
+            <p id="game-status-meta" class="status-meta"></p>
+          </div>
+          <button type="button" id="toggle-game-status">Close game</button>
+        </div>
+        <form id="question-form">
+          <input type="hidden" id="question-id" />
+          <div class="form-control">
+            <label for="question-level" data-i18n="admin.level">Question level (1-15)</label>
+            <input id="question-level" type="number" min="1" max="15" required />
+          </div>
+          <div class="form-control">
+            <label for="question-difficulty" data-i18n="admin.difficulty">Difficulty</label>
+            <select id="question-difficulty">
+              <option value="easy" data-i18n="admin.difficulties.easy">Easy</option>
+              <option value="medium" data-i18n="admin.difficulties.medium">Medium</option>
+              <option value="hard" data-i18n="admin.difficulties.hard">Hard</option>
+            </select>
+          </div>
+          <div class="form-control">
+            <label for="question-en" data-i18n="admin.questionEn">Question (English)</label>
+            <textarea id="question-en" rows="2" required></textarea>
+          </div>
+          <div class="form-control">
+            <label for="question-ar" data-i18n="admin.questionAr">Question (Arabic)</label>
+            <textarea id="question-ar" rows="2" required></textarea>
+          </div>
+          <div class="form-control">
+            <label data-i18n="admin.answersEn">Answers (English)</label>
+            <div>
+              <input data-option-en="0" placeholder="Answer A" required />
+              <input data-option-en="1" placeholder="Answer B" required />
+              <input data-option-en="2" placeholder="Answer C" required />
+              <input data-option-en="3" placeholder="Answer D" required />
+            </div>
+          </div>
+          <div class="form-control">
+            <label data-i18n="admin.answersAr">Answers (Arabic)</label>
+            <div>
+              <input data-option-ar="0" placeholder="الإجابة أ" required />
+              <input data-option-ar="1" placeholder="الإجابة ب" required />
+              <input data-option-ar="2" placeholder="الإجابة ج" required />
+              <input data-option-ar="3" placeholder="الإجابة د" required />
+            </div>
+          </div>
+          <div class="form-control">
+            <label for="correct-index" data-i18n="admin.correct">Correct answer index</label>
+            <select id="correct-index">
+              <option value="0">A</option>
+              <option value="1">B</option>
+              <option value="2">C</option>
+              <option value="3">D</option>
+            </select>
+          </div>
+          <button type="submit" data-i18n="admin.saveQuestion">Save question</button>
+          <button type="button" id="reset-form" class="secondary" data-i18n="admin.reset">
+            Reset form
+          </button>
+        </form>
+        <div class="admin-list" id="question-list"></div>
+      </section>
+    </main>
+
+    <script type="module" src="./app.js"></script>
   </body>
 </html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,442 @@
+:root {
+  --primary-bg: #0b1634;
+  --secondary-bg: #12264f;
+  --accent: #f7b400;
+  --accent-strong: #f79e00;
+  --text-light: #f5f6f8;
+  --text-muted: #9aa3bc;
+  --success: #00c853;
+  --danger: #ff5252;
+  --card-radius: 16px;
+  --transition: 0.25s ease;
+  font-size: 16px;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html, body {
+  min-height: 100%;
+  background: radial-gradient(circle at top, #11255a, #02050d 65%);
+  color: var(--text-light);
+  font-family: "Poppins", "Tajawal", sans-serif;
+}
+
+body {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  padding: 2rem 1rem 4rem;
+}
+
+header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+header h1 {
+  font-size: clamp(2.2rem, 4vw, 3rem);
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  color: var(--accent);
+  text-shadow: 0 0 12px rgba(247, 180, 0, 0.6);
+}
+
+.language-toggle {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: center;
+  margin-top: 0.5rem;
+}
+
+.language-toggle button {
+  background: transparent;
+  border: 1px solid var(--accent);
+  border-radius: 999px;
+  color: var(--accent);
+  padding: 0.35rem 0.9rem;
+  cursor: pointer;
+  transition: var(--transition);
+  font-weight: 600;
+}
+
+.language-toggle button.active,
+.language-toggle button:hover {
+  background: var(--accent);
+  color: #06102a;
+}
+
+main {
+  width: min(1200px, 100%);
+  display: grid;
+  gap: 1.5rem;
+}
+
+.card {
+  background: rgba(9, 19, 42, 0.86);
+  border-radius: var(--card-radius);
+  padding: 1.5rem;
+  box-shadow: 0 18px 55px rgba(0, 0, 0, 0.35);
+  border: 1px solid rgba(247, 180, 0, 0.12);
+  backdrop-filter: blur(10px);
+}
+
+.hidden {
+  display: none !important;
+}
+
+.form-control {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  margin-bottom: 1rem;
+}
+
+.form-control label {
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.form-control input,
+.form-control textarea,
+.form-control select {
+  border: none;
+  border-radius: 10px;
+  padding: 0.75rem 1rem;
+  background: rgba(11, 22, 52, 0.65);
+  color: var(--text-light);
+  outline: none;
+  transition: var(--transition);
+}
+
+.form-control input:focus,
+.form-control textarea:focus,
+.form-control select:focus {
+  box-shadow: 0 0 0 2px rgba(247, 180, 0, 0.25);
+}
+
+button {
+  border: none;
+  border-radius: 12px;
+  padding: 0.75rem 1.5rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: var(--transition);
+  background: linear-gradient(120deg, #183773, #0d1f47);
+  color: var(--text-light);
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.35);
+}
+
+button:disabled {
+  opacity: 0.45;
+  filter: grayscale(0.3);
+  pointer-events: none;
+}
+
+button.secondary {
+  background: transparent;
+  border: 1px solid rgba(247, 180, 0, 0.5);
+  color: var(--accent);
+  letter-spacing: normal;
+}
+
+button.danger {
+  background: linear-gradient(120deg, #7a1021, #4d0a16);
+}
+
+.auth-forms {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+}
+
+.status-banner {
+  background: rgba(8, 32, 72, 0.7);
+  border-radius: 14px;
+  padding: 1rem;
+  margin-bottom: 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.status-banner span {
+  font-weight: 600;
+}
+
+.status-banner h2 {
+  margin: 0;
+  font-size: 1.35rem;
+}
+
+.notice {
+  margin-top: 1rem;
+  padding: 0.85rem 1rem;
+  background: rgba(122, 16, 33, 0.25);
+  border: 1px solid rgba(255, 82, 82, 0.4);
+  border-radius: 12px;
+  font-weight: 600;
+  text-align: center;
+  color: var(--text-light);
+}
+
+.admin-control-card {
+  display: flex;
+  gap: 1.25rem;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: 1.5rem;
+  padding: 1.25rem;
+  border-radius: 14px;
+  background: rgba(10, 24, 55, 0.8);
+  border: 1px solid rgba(247, 180, 0, 0.18);
+  box-shadow: inset 0 0 25px rgba(0, 0, 0, 0.25);
+}
+
+.admin-control-info {
+  flex: 1;
+  display: grid;
+  gap: 0.4rem;
+}
+
+.admin-control-card button {
+  align-self: center;
+  min-width: 170px;
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  background: rgba(0, 200, 83, 0.1);
+  color: var(--success);
+  border: 1px solid rgba(0, 200, 83, 0.45);
+  font-weight: 600;
+  letter-spacing: 0.3px;
+  width: fit-content;
+}
+
+.status-pill[data-status="closed"] {
+  background: rgba(255, 82, 82, 0.12);
+  border-color: rgba(255, 82, 82, 0.45);
+  color: var(--danger);
+}
+
+.status-meta {
+  margin-top: 0.6rem;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+#game-area {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.question-box {
+  background: linear-gradient(135deg, rgba(21, 40, 88, 0.9), rgba(9, 18, 42, 0.95));
+  border-radius: var(--card-radius);
+  padding: 1.5rem;
+  border: 1px solid rgba(247, 180, 0, 0.3);
+  box-shadow: inset 0 0 35px rgba(0, 0, 0, 0.45);
+}
+
+.question-text {
+  font-size: 1.35rem;
+  font-weight: 600;
+  text-align: center;
+  line-height: 1.5;
+  min-height: 80px;
+}
+
+.answers {
+  display: grid;
+  gap: 0.8rem;
+}
+
+.answer {
+  padding: 0.9rem 1rem;
+  border-radius: 999px;
+  background: rgba(8, 25, 60, 0.85);
+  border: 1px solid rgba(247, 180, 0, 0.3);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  cursor: pointer;
+  transition: var(--transition);
+}
+
+.answer:hover {
+  background: rgba(247, 180, 0, 0.12);
+}
+
+.answer.disabled {
+  opacity: 0.35;
+  pointer-events: none;
+}
+
+.answer.active {
+  background: rgba(247, 180, 0, 0.25);
+  border-color: var(--accent);
+}
+
+.answer.correct {
+  background: rgba(0, 200, 83, 0.2);
+  border-color: var(--success);
+}
+
+.answer.wrong {
+  background: rgba(255, 82, 82, 0.2);
+  border-color: var(--danger);
+}
+
+.lifelines {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: center;
+}
+
+.lifelines button {
+  min-width: 130px;
+}
+
+.ladder {
+  display: grid;
+  gap: 0.35rem;
+  max-height: 430px;
+  overflow-y: auto;
+}
+
+.ladder-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.55rem 0.9rem;
+  border-radius: 8px;
+  background: rgba(12, 27, 66, 0.6);
+  border: 1px solid transparent;
+  transition: var(--transition);
+  font-weight: 600;
+}
+
+.ladder-item.active {
+  border-color: var(--accent);
+  background: rgba(247, 180, 0, 0.2);
+  color: var(--accent);
+}
+
+.ladder-item.safe {
+  color: var(--success);
+}
+
+#admin-panel {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.admin-list {
+  display: grid;
+  gap: 1rem;
+}
+
+.question-card {
+  background: rgba(12, 25, 58, 0.7);
+  padding: 1rem;
+  border-radius: 12px;
+  border: 1px solid rgba(247, 180, 0, 0.2);
+  display: grid;
+  gap: 0.6rem;
+}
+
+.question-card header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin: 0;
+}
+
+.question-card header h4 {
+  font-size: 1rem;
+  color: var(--accent);
+}
+
+.option-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  background: rgba(8, 20, 50, 0.9);
+  border-radius: 999px;
+  padding: 0.35rem 0.75rem;
+  margin: 0.15rem;
+  font-size: 0.85rem;
+}
+
+@media (max-width: 768px) {
+  body {
+    padding: 1.5rem 0.6rem 3rem;
+  }
+
+  .answers {
+    grid-template-columns: 1fr;
+  }
+
+  .lifelines {
+    flex-direction: column;
+  }
+
+  button {
+    width: 100%;
+  }
+
+  .admin-control-card {
+    flex-direction: column;
+  }
+}
+
+[dir="rtl"] body {
+  font-family: "Tajawal", sans-serif;
+}
+
+[dir="rtl"] .answer {
+  flex-direction: row-reverse;
+}
+
+[dir="rtl"] .ladder-item {
+  flex-direction: row-reverse;
+}
+
+.toast {
+  position: fixed;
+  top: 1.5rem;
+  right: 1.5rem;
+  background: rgba(6, 18, 46, 0.95);
+  border: 1px solid rgba(247, 180, 0, 0.45);
+  color: var(--text-light);
+  padding: 0.9rem 1.2rem;
+  border-radius: 12px;
+  box-shadow: 0 15px 30px rgba(0, 0, 0, 0.35);
+  opacity: 0;
+  transform: translateY(-10px);
+  pointer-events: none;
+  transition: opacity 0.3s ease, transform 0.3s ease;
+  z-index: 999;
+}
+
+.toast.visible {
+  opacity: 1;
+  transform: translateY(0);
+}


### PR DESCRIPTION
## Summary
- add an availability control card in the admin panel and a menu notice for closed sessions
- connect a Firestore-backed listener and toggle logic to manage global game availability in both languages
- prevent players from starting or resuming games while the experience is closed

## Testing
- node --check public/app.js

------
https://chatgpt.com/codex/tasks/task_e_68f9b3f2d7f4832ea2aebfb105e41423
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/alitravians/ali/pull/21">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
